### PR TITLE
Add an extension id to replace auto generated id 

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,4 +1,9 @@
 {
+	"browser_specific_settings": {
+  		"gecko": {
+    			"id": "favicon-switcher@seanfeng.dev"
+  		}
+	},
 	"manifest_version": 2,
 	"name": "FaviconSwitcher",
 	"version": "0.2.2",

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"manifest_version": 2,
 	"name": "FaviconSwitcher",
-	"version": "0.2.1",
+	"version": "0.2.2",
 
 	"description": "Replace ugly favicon by uploading your own images.",
 


### PR DESCRIPTION
Add an extension id to replace auto generated id. 

Fix: https://github.com/sefeng211/faviconSwitcher/issues/8